### PR TITLE
Update abortable fetch article for Chrome support

### DIFF
--- a/src/content/en/updates/2017/09/abortable-fetch.md
+++ b/src/content/en/updates/2017/09/abortable-fetch.md
@@ -2,7 +2,7 @@ project_path: /web/_project.yaml
 book_path: /web/updates/_book.yaml
 description: Aborting fetches using a new web primitive – The abort controller.
 
-{# wf_updated_on: 2017-10-25 #}
+{# wf_updated_on: 2018-06-07 #}
 {# wf_published_on: 2017-09-28 #}
 {# wf_tags: fetch #}
 {# wf_featured_image: /web/updates/images/2017/09/abortable-fetch.png #}
@@ -148,8 +148,8 @@ errors, an error is shown, *unless* it's an abort error:
 Note: This example uses [async
 functions](/web/fundamentals/getting-started/primers/async-functions).
 
-**[Here's a demo](https://fetch-svg-abort.glitch.me/)** – At time of writing, the only browsers that
-support this are Edge 16 and Firefox 57.
+**[Here's a demo](https://fetch-svg-abort.glitch.me/)** – At time of writing, this works in
+Edge 16, Firefox 57 and Chrome 66.
 
 ## One signal, many fetches
 
@@ -183,12 +183,15 @@ In this case, calling `controller.abort()` will abort whichever fetches are in-p
 
 ### Other browsers
 
-Edge did a great job to ship this first, and Firefox are hot on their trail. Their engineers
+Edge did a great job to ship this first, with Firefox hot on their trail. Their engineers
 implemented from the [test
 suite](https://github.com/w3c/web-platform-tests/tree/master/fetch/api/abort) while the spec was
-being written. For other browsers, here are the tickets to follow:
+being written.
 
-* [Chrome](https://bugs.chromium.org/p/chromium/issues/detail?id=750599).
+Chrome caught up in version 66.
+
+For other browsers, here are the tickets to follow:
+
 * [Safari](https://bugs.webkit.org/show_bug.cgi?id=174980).
 
 ### In a service worker


### PR DESCRIPTION
Chrome has supported Abortable fetch since version 66. Update the abortable fetch article to reflect this.

What's changed, or what was fixed?
- Reflect that Chrome supports abortable fetch.
- Slightly change wording since Firefox support happened a while ago.

**Target Live Date:** YYYY-MM-DD

- [ ] This has been reviewed and approved by (NAME)
- [ ] I have run `gulp test` locally and all tests pass.
- [ ] I have added the appropriate `type-something` label.
- [ ] I've staged the site and manually verified that my content displays correctly.

**CC:** @petele
